### PR TITLE
fix: check whether the target is a directory or a file before removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colligo"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "clap",


### PR DESCRIPTION
- I modified the code to check whether the target is a directory or a file before performing the removal.

#10 