### PR TITLE
Fix copydir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2025-12-09
+
+### Removed
+
+- Check for empty or non-existing directory prior to initialize repository.
+
+### Fixed
+
+- copydir action was not working when destination existed.
+
 ## [0.6.1] - 2025-12-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colligo"
-version = "0.6.0"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "colligo"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 [dependencies]

--- a/src/application.rs
+++ b/src/application.rs
@@ -387,7 +387,7 @@ fn execute_actions(manifest_dir: &Path, project: &Project) -> Result<(), Manifes
                         src.display(),
                         dest.display()
                     );
-                     ManifestError::FailedToExecuteAction(msg)
+                    ManifestError::FailedToExecuteAction(msg)
                 })?;
             }
             ProjectAction::FileAction(ProjectFileAction::CopyDir(src, dest)) => {
@@ -416,10 +416,10 @@ fn execute_actions(manifest_dir: &Path, project: &Project) -> Result<(), Manifes
 }
 
 pub fn save_file(filename: &String, content: &String) -> Result<(), ManifestError> {
-    let mut file = File::create(filename).map_err(|e|{
-            let msg = format!("Failed to create file {filename}: {e}");
-            ManifestError::FailedToSaveFile(msg)
-        })?;
+    let mut file = File::create(filename).map_err(|e| {
+        let msg = format!("Failed to create file {filename}: {e}");
+        ManifestError::FailedToSaveFile(msg)
+    })?;
 
     file.write(content.as_bytes()).map_err(|e| {
         let msg = format!("Failed to write to file {filename}: {e}");
@@ -430,9 +430,10 @@ pub fn save_file(filename: &String, content: &String) -> Result<(), ManifestErro
 
 pub fn assert_dependencies() -> Result<(), ManifestError> {
     const GIT: &str = "git";
-    Command::new(GIT).arg("--version").output().map_err(|_| {
-        ManifestError::MissingDependency(GIT.to_string())
-    })?;
+    Command::new(GIT)
+        .arg("--version")
+        .output()
+        .map_err(|_| ManifestError::MissingDependency(GIT.to_string()))?;
     Ok(())
 }
 

--- a/tests/manifest.xml
+++ b/tests/manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <manifest>
     <!-- Project's default settings -->
-    <default revision="main" uri="gitlab.com"/>
+    <default revision="main" uri="github.com"/>
 
     <!-- path is relative from where manifest is executed -->
     <project name="repo/name" path="path/folder" revision="branch"/>

--- a/tests/manifest_copydir.xml
+++ b/tests/manifest_copydir.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <manifest>
     <!-- Project's dependencies -->
-    <default revision="main" uri="gitlab.com"/>
+    <default revision="main" uri="github.com"/>
 
     <!-- src path is relative to the project path -->
     <!-- dest path is relative to the manifest file -->
-    <project uri="gitlab.com" name="cdsa_rust/colligo" path="./dev/folder">
+    <project uri="github.com" name="chrisdsa/colligo" path="./dev/folder">
         <copydir src="../folder" dest="./new_dev"/>
     </project>
 

--- a/tests/manifest_del_repo.xml
+++ b/tests/manifest_del_repo.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <manifest>
     <!-- Project's dependencies -->
-    <default revision="main" uri="gitlab.com"/>
+    <default revision="main" uri="github.com"/>
 
     <!-- A Section -->
     <!-- path is relative to the manifest file -->
-    <project name="cdsa_rust/colligo" path="./dev" revision="dev"/>
-    <project name="cdsa_rust/colligo" path="release/v0" revision="v0.0.0"/>
+    <project name="chrisdsa/colligo" path="./dev" revision="dev"/>
+    <project name="chrisdsa/colligo" path="release/v0" revision="v0.0.0"/>
 
     <!-- B Section -->
     <!-- src path is relative to the manifest file -->
     <!-- dest path is relative to the project path -->
-    <project uri="gitlab.com" name="cdsa_rust/colligo" path="./no_revision" revision="dev">
+    <project uri="github.com" name="chrisdsa/colligo" path="./no_revision" revision="dev">
         <delete_project/>
         <copyfile src="./README.md" dest="./new_folder/ln_README.md"/>
         <delete_project/>

--- a/tests/manifest_example.xml
+++ b/tests/manifest_example.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <manifest>
     <!-- Project's dependencies -->
-    <default revision="main" uri="gitlab.com"/>
+    <default revision="main" uri="github.com"/>
 
     <!-- A Section -->
     <!-- path is relative to the manifest file -->
-    <project name="cdsa_rust/colligo" path="./dev" revision="dev"/>
-    <project name="cdsa_rust/colligo" path="release/v0" revision="v0.0.0"/>
+    <project name="chrisdsa/colligo" path="./dev" revision="dev"/>
+    <project name="chrisdsa/colligo" path="release/v0" revision="v0.0.0"/>
 
     <!-- B Section -->
     <!-- src path is relative to the project path -->
     <!-- dest path is relative to the manifest file -->
-    <project uri="gitlab.com" name="cdsa_rust/colligo" path="./no_revision">
+    <project uri="github.com" name="chrisdsa/colligo" path="./no_revision">
         <linkfile src="./README.md" dest="./new_folder/ln_README.md"/>
         <copyfile src="./README.md" dest="./cp_README.md"/>
     </project>

--- a/tests/manifest_symlink_dir.xml
+++ b/tests/manifest_symlink_dir.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest>
+    <!-- Project's dependencies -->
+    <default revision="main" uri="github.com"/>
+
+    <!-- A Section -->
+    <!-- path is relative to the manifest file -->
+    <project name="chrisdsa/colligo" path="./dev" revision="dev"/>
+    <project name="chrisdsa/colligo" path="release/v0" revision="v0.0.0"/>
+
+    <!-- B Section -->
+    <!-- src path is relative to the project path -->
+    <!-- dest path is relative to the manifest file -->
+    <project uri="github.com" name="chrisdsa/colligo" path="./no_revision">
+        <linkfile src="./README.md" dest="./new_folder/ln_README.md"/>
+        <linkfile src="./src" dest="./new_folder/src_linked"/>
+        <copyfile src="./README.md" dest="./cp_README.md"/>
+    </project>
+
+</manifest>

--- a/tests/pinned_manifest_example.xml
+++ b/tests/pinned_manifest_example.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-    <project uri="gitlab.com" name="cdsa_rust/colligo" path="./dev" revision="565b113e57b2c67dcaa3e7c2b5040cf4715221df"/>
-    <project uri="gitlab.com" name="cdsa_rust/colligo" path="release/v0" revision="565b113e57b2c67dcaa3e7c2b5040cf4715221df"/>
-    <project uri="gitlab.com" name="cdsa_rust/colligo" path="./no_revision" revision="565b113e57b2c67dcaa3e7c2b5040cf4715221df">
+    <project uri="github.com" name="chrisdsa/colligo" path="./dev" revision="565b113e57b2c67dcaa3e7c2b5040cf4715221df"/>
+    <project uri="github.com" name="chrisdsa/colligo" path="release/v0" revision="633fcde4a51809adfffa2d65d68a3ac687d93826"/>
+    <project uri="github.com" name="chrisdsa/colligo" path="./no_revision" revision="61518393fd65f7bf57be144f4498112d5c503d36">
         <linkfile src="./README.md" dest="./ln_README.md"/>
         <copyfile src="./README.md" dest="./cp_README.md"/>
     </project>

--- a/tests/test_application.rs
+++ b/tests/test_application.rs
@@ -132,7 +132,11 @@ mod test_application {
             .expect("Failed to create file");
         std::fs::File::create(temp_dir.path().join("cp_README.md")).expect("Failed to create file");
         // create symlink to a directory
-        std::os::unix::fs::symlink(&project_0_path, temp_dir.path().join("./new_folder/src_linked")).expect("failed to create symlink");
+        std::os::unix::fs::symlink(
+            &project_0_path,
+            temp_dir.path().join("./new_folder/src_linked"),
+        )
+        .expect("failed to create symlink");
 
         // Test
         let mut manifest =

--- a/tests/test_manifest.rs
+++ b/tests/test_manifest.rs
@@ -23,7 +23,7 @@ mod test_xml {
         assert_eq!(revision, Some("main"));
 
         let uri = default.attribute("uri");
-        assert_eq!(uri, Some("gitlab.com"));
+        assert_eq!(uri, Some("github.com"));
 
         // Projects
         let project_cnt = manifest

--- a/tests/test_xml_parser.rs
+++ b/tests/test_xml_parser.rs
@@ -13,8 +13,8 @@ mod test_xml_parser {
         let file = std::fs::read_to_string(MANIFEST_PATH).expect("Unable to read file");
         let manifest = parser.parse(&file).expect("Unable to parse XML");
 
-        const PROJECT_URI_SSH: &str = "git@gitlab.com:cdsa_rust/colligo.git";
-        const PROJECT_URI_HTTPS: &str = "https://gitlab.com/cdsa_rust/colligo.git";
+        const PROJECT_URI_SSH: &str = "git@github.com:chrisdsa/colligo.git";
+        const PROJECT_URI_HTTPS: &str = "https://github.com/chrisdsa/colligo.git";
         const PROJECT_0_PATH: &str = "./dev";
         const PROJECT_1_PATH: &str = "release/v0";
         const PROJECT_2_PATH: &str = "./no_revision";


### PR DESCRIPTION
- Fix copydir action
- Replace match statement with unused Ok() by map_err()
- Improve and update tests. Use github.com instead of gitlab, etc.
- Remove check for non existing or empty directory. Since git clone is not used anymore, this is not needed.